### PR TITLE
Add date of fix to location

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 26
         versionCode 120
-        versionName "1.2.0"
+        versionName "1.2.1"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/tranquvis/simplesmsremote/CommandManagement/Commands/CommandGetLocationCoordinates.java
+++ b/app/src/main/java/tranquvis/simplesmsremote/CommandManagement/Commands/CommandGetLocationCoordinates.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.location.Location;
 import android.support.annotation.Nullable;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 
 import tranquvis.simplesmsremote.CommandManagement.CommandExecResult;
@@ -48,12 +50,15 @@ public class CommandGetLocationCoordinates extends Command {
         String mapsLinkParam = String.format(Locale.ENGLISH, "%1$.4f,%2$.4f",
                 location.getLatitude(), location.getLongitude());
         String mapsLink = "https://www.google.com/maps?q=" + mapsLinkParam;
+        // get timestamp in RFC3339 format
+        String timestamp = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+                .format(new Date(location.getTime()));
         String accuracy = location.hasAccuracy()
                 ? String.format(Locale.getDefault(), "%1$.0fm radius (68%% probability)", location.getAccuracy())
                 : context.getString(R.string.unknown_accuracy);
         // see https://developer.android.com/reference/android/location/Location.html#getAccuracy()
         result.setCustomResultMessage(context.getString(
-                R.string.result_msg_location_coordinates, locationDescription, accuracy, mapsLink));
+                R.string.result_msg_location_coordinates, locationDescription, timestamp, accuracy, mapsLink));
         result.setForceSendingResultSmsMessage(true);
     }
 }

--- a/app/src/main/res/values/strings_result_messages.xml
+++ b/app/src/main/res/values/strings_result_messages.xml
@@ -4,7 +4,7 @@
     <string name="result_msg_battery_is_charging_false">battery is not charging</string>
     <string name="result_msg_battery_is_charging_true">battery is charging</string>
 
-    <string name="result_msg_location_coordinates">location: %1$s\naccuracy: %2$s\n%3$s</string>
+    <string name="result_msg_location_coordinates">location: %1$s\ndate: %2$s\naccuracy: %3$s\n%4$s</string>
 
     <string name="result_msg_hotspot_is_enabled_false">hotspot is not enabled</string>
     <string name="result_msg_hotspot_is_enabled_true">hotspot is enabled</string>


### PR DESCRIPTION
The location API might return old locations. The user might not realize that he got a wrong location.

This pull request adds a date field to the return message:
- Date/Time is RFC3339 format
- Message is still less than 160 letters
